### PR TITLE
Fix typo in MarketApproxEstimateLib comment

### DIFF
--- a/contracts/router/math/MarketApproxEstimateLib.sol
+++ b/contracts/router/math/MarketApproxEstimateLib.sol
@@ -83,7 +83,7 @@ library MarketApproxEstimateLib {
         //   => pa = totalPt / totalSy * sa
         //
         // +) Let `syToPtRate` be the spot price between the PT and SY amount.
-        //    Conversion between exessive/missing parts need to respect the
+        //    Conversion between excessive/missing parts need to respect the
         //    current price:
         //      (sa - netSyOwning) * syToPtRate = netPtOwning - pa
         //  <=> (sa - netSyOwning) * syToPtRate = netPtOwning - totalPt / totalSy * sa


### PR DESCRIPTION
## Summary
Fixed typo in code comment:
- "exessive" -> "excessive" in contracts/router/math/MarketApproxEstimateLib.sol

## Test plan
- [x] Comment-only change, no functional code changes
- [x] Verified spelling is correct