### PR TITLE
Fix duplicate word in LimitRouterBase comment

### DIFF
--- a/contracts/limit/LimitRouterBase.sol
+++ b/contracts/limit/LimitRouterBase.sol
@@ -294,7 +294,7 @@ abstract contract LimitRouterBase is
         return (orderHash, remainingMakerAmount, filledMakerAmount);
     }
 
-    // ----------------- simple helper functions functions -----------------
+    // ----------------- simple helper functions -----------------
 
     function _transferFromMakers_mintSy_updMakings(address SY, FillOrderParams[] memory params)
         internal


### PR DESCRIPTION
## Summary
Fixed duplicate word in section header comment:
- "functions functions" -> "functions" in contracts/limit/LimitRouterBase.sol (line 297)

## Test plan
- [x] Comment-only change, no functional code changes
- [x] Verified the section header now reads correctly