### PR TITLE
Fix grammar in LiquidityMining README

### DIFF
--- a/contracts/LiquidityMining/README.md
+++ b/contracts/LiquidityMining/README.md
@@ -9,7 +9,7 @@
 - As such, we just need to store $bias_u$ and $slope_u$ for each user. (Considerations: store $bias_u$ and $t_{expiry}$ for the user instead, because $t_{expiry}$ is always an exact number)
 - The amount of PENDLE locked by user $u$ is $locked_u$
 - For total supply, it's simply $totalBalance = totalBias - totalSlope * t$
-- Possible actions by an user:
+- Possible actions by a user:
   - User $u$ create a new lock by locking $d_{PENDLE}$ of PENDLE tokens, expiring at $t_{expiry}$
     $slope_u = d_{PENDLE} / MAXLOCKTIME$
     $bias_u = slope_u \cdot t_{expiry}$


### PR DESCRIPTION
## Summary
Fixed grammar issue in contracts/LiquidityMining/README.md:
- "an user" -> "a user" (line 12)

The indefinite article "a" should be used before words beginning with consonant sounds, while "an" is used before vowel sounds. "User" starts with a consonant sound (y-oo-zer), so "a" is correct.

## Test plan
- [x] Documentation-only change, no functional code changes
- [x] Verified grammar is correct