### PR TITLE
Fix word usage in LiquidityMining README

### DIFF
--- a/contracts/LiquidityMining/README.md
+++ b/contracts/LiquidityMining/README.md
@@ -54,7 +54,7 @@
 
 Gauge controller will receive the voting results from VotingController and incentivize the amount of PENDLE from `block.timestamp` to `block.timestamp + 1 WEEK`.
 
-If there is still leftover reward in each pool, the gauge controller will remove and take the leftover to top up the incentivize for the current week.
+If there is still leftover reward in each pool, the gauge controller will remove and take the leftover to top up the incentives for the current week.
 
 ### Gauge & Market
 


### PR DESCRIPTION
## Summary
Fixed incorrect word usage in contracts/LiquidityMining/README.md:
- "incentivize" -> "incentives" (line 57)

The sentence should use the noun "incentives" rather than the verb "incentivize" in this context: "to top up the incentives for the current week."

## Test plan
- [x] Documentation-only change, no functional code changes
- [x] Verified the sentence now reads correctly