### PR TITLE
[infra] enforce npm package age gate (14 days)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,8 @@
+npmMinimalAgeGate: 14d
+
+npmMinimalAgeGateExclusions:
+  - "@pendle/*"
+
 compressionLevel: mixed
 
 enableGlobalCache: false

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,6 @@
 npmMinimalAgeGate: 14d
 
-npmMinimalAgeGateExclusions:
+npmPreapprovedPackages:
   - "@pendle/*"
 
 compressionLevel: mixed


### PR DESCRIPTION
## Summary
- Adds `npmMinimalAgeGate: 14d` to `.yarnrc.yml` — Yarn will refuse to resolve any package version published less than 14 days ago
- Excludes `@pendle/*` scoped packages via `npmPreapprovedPackages`
- Part of org-wide supply chain security hardening

## Test plan
- [ ] Verify `yarn install` works without issues
- [ ] Verify `yarn add <recent-package>` is blocked if published < 14 days ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)